### PR TITLE
Restart should also run the containers in the background

### DIFF
--- a/lib/capistrano/tasks/decompose.rake
+++ b/lib/capistrano/tasks/decompose.rake
@@ -34,7 +34,7 @@ namespace :decompose do
         services = Array(fetch(:decompose_restart))
         if services.empty?
           docker_execute :down
-          docker_execute :up
+          docker_execute :up, '-d'
         else
           docker_execute :stop, *services
           docker_execute :up, '-d', *services


### PR DESCRIPTION
I found on a fresh deploy to a new server that the deploy hangs/fails because the container does not go into the background.  The up method properly demonizes the process.

This should address the issue.